### PR TITLE
rotate without changing size

### DIFF
--- a/src/utils/makeScanned/processConfig.ts
+++ b/src/utils/makeScanned/processConfig.ts
@@ -19,7 +19,7 @@ export function getProcessCommand(
   args.push(inputFilename);
 
   if (thresholdFunc(rotate)) {
-    args.push(`-rotate ${rotate.toFixed(2)} +repage`);
+    args.push(`-distort SRT ${rotate.toFixed(2)} +repage`);
   }
 
   args.push(`-colorspace ${colorspace}`);


### PR DESCRIPTION
Rotate the content without changing its size. Real paper doesn't change its size when it's rotated.