### PR TITLE
add border setting

### DIFF
--- a/src/components/ScanSettings/ScanSettingsCard.vue
+++ b/src/components/ScanSettings/ScanSettingsCard.vue
@@ -7,6 +7,7 @@
 
     <!-- Scan Settings -->
     <ColorspaceSetting v-model:colorspace="config.colorspace" />
+    <BorderSetting v-model:border="config.border" />
     <RotateSetting v-model:rotate="config.rotate" />
     <BlurSetting v-model:blur="config.blur" />
     <AttenuateSetting v-model:attenuate="config.attenuate" />
@@ -30,6 +31,7 @@ import PDFSelection from "./PDFSelection.vue";
 
 import RotateSetting from "./Settings/RotateSetting.vue";
 import ColorspaceSetting from "./Settings/ColorspaceSetting.vue";
+import BorderSetting from "./Settings/BorderSetting.vue";
 import BlurSetting from "./Settings/BlurSetting.vue";
 import AttenuateSetting from "./Settings/AttenuateSetting.vue";
 

--- a/src/components/ScanSettings/Settings/BorderSetting.vue
+++ b/src/components/ScanSettings/Settings/BorderSetting.vue
@@ -1,0 +1,40 @@
+<template>
+  <v-list-item two-line>
+    <v-list-item-header>
+      <v-list-item-title>Border</v-list-item-title>
+      <v-switch
+        v-model="borderSwitch"
+        color="success"
+        :label="borderSwitch ? 'Yes' : 'No'"
+        hide-details
+        density="compact"
+      ></v-switch>
+    </v-list-item-header>
+  </v-list-item>
+</template>
+
+<script lang="ts" setup>
+import type { ProcessConfig } from "@/utils/makeScanned";
+import { computed } from "vue";
+
+type borderType = ProcessConfig["border"];
+
+const props = defineProps<{
+  border: borderType;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:border", value: borderType): void;
+}>();
+
+const borderSwitch = computed({
+  get: () => props.border == true,
+  set: (border) => emit("update:border", border ? true : false),
+});
+</script>
+
+<style>
+.v-select > div.v-input__control > div > div.v-field__overlay {
+  background-color: inherit;
+}
+</style>

--- a/src/utils/makeScanned/defaultConfig.ts
+++ b/src/utils/makeScanned/defaultConfig.ts
@@ -6,4 +6,5 @@ export const defaultConfig: ProcessConfig = {
   blur: 0.5,
   attenuate: 0.25,
   noise: "Gaussian",
+  border: true
 };

--- a/src/utils/makeScanned/defaultConfig.ts
+++ b/src/utils/makeScanned/defaultConfig.ts
@@ -6,5 +6,5 @@ export const defaultConfig: ProcessConfig = {
   blur: 0.5,
   attenuate: 0.25,
   noise: "Gaussian",
-  border: true
+  border: false
 };

--- a/src/utils/makeScanned/processConfig.ts
+++ b/src/utils/makeScanned/processConfig.ts
@@ -5,6 +5,7 @@ export interface ProcessConfig {
   blur: number;
   attenuate: number;
   noise: string;
+  border: boolean;
 }
 
 export function getProcessCommand(
@@ -12,11 +13,15 @@ export function getProcessCommand(
   inputFilename: string,
   outputFilename: string
 ): string {
-  const { rotate, colorspace, blur, attenuate, noise } = config;
+  const { rotate, colorspace, blur, attenuate, noise, border } = config;
   const thresholdFunc = (value: number) => !(value > -0.1 && value < 0.1);
   const args: string[] = [];
   args.push("convert");
   args.push(inputFilename);
+
+  if (thresholdFunc(border) == true) {
+    args.push("-bordercolor black -border 1 -bordercolor white -border 1");
+  }
 
   if (thresholdFunc(rotate)) {
     args.push(`-distort SRT ${rotate.toFixed(2)} +repage`);


### PR DESCRIPTION
This PR implements an additional setting that adds a thin black border to the "scanned" page.

The added button:
![toggle](https://user-images.githubusercontent.com/17005217/164223266-8925fff1-3dc4-4894-8ef6-23be1f425089.png)

The result:
![result](https://user-images.githubusercontent.com/17005217/164223285-8856f427-4527-4447-ac8b-d7ad0f63bdd8.png)

