### PR TITLE
fix rotation bug introduced in #3

### DIFF
--- a/src/utils/makeScanned/processConfig.ts
+++ b/src/utils/makeScanned/processConfig.ts
@@ -20,11 +20,11 @@ export function getProcessCommand(
   args.push(inputFilename);
 
   if (border) {
-    args.push("-bordercolor black -border 1 -bordercolor white -border 1");
+    args.push("-bordercolor black -border 1");
   }
 
   if (thresholdFunc(rotate)) {
-    args.push(`-distort SRT ${rotate.toFixed(2)} +repage`);
+    args.push(`-background white -virtual-pixel background -distort SRT ${rotate.toFixed(2)} +repage`);
   }
 
   args.push(`-colorspace ${colorspace}`);


### PR DESCRIPTION
Due to a bug I introduced in #3, the color of a rotated page would smear across the page. This would lead to discolorations in the output if the edge of the page wasn't white. This PR fixes it.

This also makes the double-border workaround introduced in #6 no longer necessary.

Before:
![before](https://user-images.githubusercontent.com/17005217/164705858-9c8a93e1-758f-493d-8adb-1621006bae94.png)

After:
![after](https://user-images.githubusercontent.com/17005217/164705900-f886bf26-34c4-4124-816b-5c57d1e368cb.png)
 