### PR TITLE
Add punch hole & black background options

### DIFF
--- a/src/components/ScanSettings/ScanSettingsCard.vue
+++ b/src/components/ScanSettings/ScanSettingsCard.vue
@@ -7,7 +7,7 @@
 
     <!-- Scan Settings -->
     <ColorspaceSetting v-model:colorspace="config.colorspace" />
-    <BorderSetting v-model:border="config.border" />
+    <BackgroundSetting v-model:background="config.background" />
     <PunchHoleSetting v-model:punchHoles="config.punchHoles" />
     <RotateSetting v-model:rotate="config.rotate" />
     <RotateVarianceSetting v-model:rotate_var="config.rotate_var" />
@@ -31,7 +31,7 @@
 <script lang="ts" setup>
 import PDFSelection from "./PDFSelection.vue";
 
-import BorderSetting from "./Settings/BorderSetting.vue";
+import BackgroundSetting from "./Settings/BackgroundSetting.vue";
 import PunchHoleSetting from "./Settings/PunchHoleSetting.vue";
 import RotateSetting from "./Settings/RotateSetting.vue";
 import RotateVarianceSetting from "./Settings/RotateVarianceSetting.vue";

--- a/src/components/ScanSettings/ScanSettingsCard.vue
+++ b/src/components/ScanSettings/ScanSettingsCard.vue
@@ -8,6 +8,7 @@
     <!-- Scan Settings -->
     <ColorspaceSetting v-model:colorspace="config.colorspace" />
     <BorderSetting v-model:border="config.border" />
+    <PunchHoleSetting v-model:punchHoles="config.punchHoles" />
     <RotateSetting v-model:rotate="config.rotate" />
     <RotateVarianceSetting v-model:rotate_var="config.rotate_var" />
     <BlurSetting v-model:blur="config.blur" />
@@ -31,6 +32,7 @@
 import PDFSelection from "./PDFSelection.vue";
 
 import BorderSetting from "./Settings/BorderSetting.vue";
+import PunchHoleSetting from "./Settings/PunchHoleSetting.vue";
 import RotateSetting from "./Settings/RotateSetting.vue";
 import RotateVarianceSetting from "./Settings/RotateVarianceSetting.vue";
 import ColorspaceSetting from "./Settings/ColorspaceSetting.vue";

--- a/src/components/ScanSettings/Settings/BackgroundSetting.vue
+++ b/src/components/ScanSettings/Settings/BackgroundSetting.vue
@@ -3,7 +3,10 @@
     <v-list-item-header>
       <v-list-item-title>Background</v-list-item-title>
        <v-radio-group
-       v-model="backgroundButtons" row>
+       v-model="backgroundButtons"
+       inline="true"
+       hide-details="true"
+       >
          <v-radio
            label="White"
            value="White"
@@ -45,20 +48,5 @@ const backgroundButtons = computed({
 .v-select > div.v-input__control > div > div.v-field__overlay {
   background-color: inherit;
 }
-
-.v-radio-group .v-input__details {
-    display: none;
- }
-
- .v-radio-group .v-selection-control {
-    display: inline-block;
-    white-space: nowrap;
-    width:auto;
-    padding-right: 3%;
- }
-
- .v-radio-group .v-selection-control .v-label {
-    vertical-align: text-bottom;
- }
 
 </style>

--- a/src/components/ScanSettings/Settings/BackgroundSetting.vue
+++ b/src/components/ScanSettings/Settings/BackgroundSetting.vue
@@ -2,13 +2,21 @@
   <v-list-item two-line>
     <v-list-item-header>
       <v-list-item-title>Background</v-list-item-title>
-      <v-switch
-        v-model="backgroundSwitch"
-        color="success"
-        :label="backgroundSwitch ? 'Yes' : 'No'"
-        hide-details
-        density="compact"
-      ></v-switch>
+       <v-radio-group
+       v-model="backgroundButtons" row>
+         <v-radio
+           label="White"
+           value="White"
+         ></v-radio>
+         <v-radio
+           label="Black Border"
+           value="Black Border"
+         ></v-radio>
+         <v-radio
+           label="Black"
+           value="Black"
+         ></v-radio>
+       </v-radio-group>
     </v-list-item-header>
   </v-list-item>
 </template>
@@ -27,9 +35,9 @@ const emit = defineEmits<{
   (e: "update:background", value: backgroundType): void;
 }>();
 
-const backgroundSwitch = computed({
-  get: () => props.background == true,
-  set: (background) => emit("update:background", background ? true : false),
+const backgroundButtons = computed({
+  get: () => props.background,
+  set: (background) => emit("update:background", background),
 });
 </script>
 
@@ -37,4 +45,20 @@ const backgroundSwitch = computed({
 .v-select > div.v-input__control > div > div.v-field__overlay {
   background-color: inherit;
 }
+
+.v-radio-group .v-input__details {
+    display: none;
+ }
+
+ .v-radio-group .v-selection-control {
+    display: inline-block;
+    white-space: nowrap;
+    width:auto;
+    padding-right: 3%;
+ }
+
+ .v-radio-group .v-selection-control .v-label {
+    vertical-align: text-bottom;
+ }
+
 </style>

--- a/src/components/ScanSettings/Settings/BackgroundSetting.vue
+++ b/src/components/ScanSettings/Settings/BackgroundSetting.vue
@@ -1,11 +1,11 @@
 <template>
   <v-list-item two-line>
     <v-list-item-header>
-      <v-list-item-title>Border</v-list-item-title>
+      <v-list-item-title>Background</v-list-item-title>
       <v-switch
-        v-model="borderSwitch"
+        v-model="backgroundSwitch"
         color="success"
-        :label="borderSwitch ? 'Yes' : 'No'"
+        :label="backgroundSwitch ? 'Yes' : 'No'"
         hide-details
         density="compact"
       ></v-switch>
@@ -17,19 +17,19 @@
 import type { ProcessConfig } from "@/utils/makeScanned";
 import { computed } from "vue";
 
-type borderType = ProcessConfig["border"];
+type backgroundType = ProcessConfig["background"];
 
 const props = defineProps<{
-  border: borderType;
+  background: backgroundType;
 }>();
 
 const emit = defineEmits<{
-  (e: "update:border", value: borderType): void;
+  (e: "update:background", value: backgroundType): void;
 }>();
 
-const borderSwitch = computed({
-  get: () => props.border == true,
-  set: (border) => emit("update:border", border ? true : false),
+const backgroundSwitch = computed({
+  get: () => props.background == true,
+  set: (background) => emit("update:background", background ? true : false),
 });
 </script>
 

--- a/src/components/ScanSettings/Settings/PunchHoleSetting.vue
+++ b/src/components/ScanSettings/Settings/PunchHoleSetting.vue
@@ -3,7 +3,10 @@
     <v-list-item-header>
       <v-list-item-title>Punch Holes</v-list-item-title>
       <v-radio-group
-      v-model="punchHoleButtons" row>
+      v-model="punchHoleButtons"
+      inline="true"
+      hide-details="true"
+      >
         <v-radio
           label="None"
           value="None"
@@ -44,21 +47,6 @@ const punchHoleButtons = computed({
 <style>
 .v-select > div.v-input__control > div > div.v-field__overlay {
   background-color: inherit;
-}
-
-.v-radio-group .v-input__details {
-   display: none;
-}
-
-.v-radio-group .v-selection-control {
-   display: inline-block;
-   white-space: nowrap;
-   width:auto;
-   padding-right: 3%;
-}
-
-.v-radio-group .v-selection-control .v-label {
-   vertical-align: text-bottom;
 }
 
 </style>

--- a/src/components/ScanSettings/Settings/PunchHoleSetting.vue
+++ b/src/components/ScanSettings/Settings/PunchHoleSetting.vue
@@ -9,7 +9,7 @@
           value="None"
         ></v-radio>
         <v-radio
-          label="A4"                          
+          label="A4"
           value="A4"
         ></v-radio>
         <v-radio

--- a/src/components/ScanSettings/Settings/PunchHoleSetting.vue
+++ b/src/components/ScanSettings/Settings/PunchHoleSetting.vue
@@ -1,0 +1,64 @@
+<template>
+  <v-list-item two-line>
+    <v-list-item-header>
+      <v-list-item-title>Punch Holes</v-list-item-title>
+      <v-radio-group
+      v-model="punchHoleButtons" row>
+        <v-radio
+          label="None"
+          value="None"
+        ></v-radio>
+        <v-radio
+          label="A4"                          
+          value="A4"
+        ></v-radio>
+        <v-radio
+          label="Letter"
+          value="Letter"
+        ></v-radio>
+      </v-radio-group>
+    </v-list-item-header>
+  </v-list-item>
+</template>
+
+<script lang="ts" setup>
+import type { ProcessConfig } from "@/utils/makeScanned";
+import { computed } from "vue";
+
+type punchHoleType = ProcessConfig["punchHoles"];
+
+const props = defineProps<{
+  punchHoles: punchHoleType;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:punchHoles", value: punchHoleType): void;
+}>();
+
+const punchHoleButtons = computed({
+  get: () => props.punchHoles,
+  set: (punchHoles) => emit("update:punchHoles", punchHoles),
+});
+</script>
+
+<style>
+.v-select > div.v-input__control > div > div.v-field__overlay {
+  background-color: inherit;
+}
+
+.v-radio-group .v-input__details {
+   display: none;
+}
+
+.v-radio-group .v-selection-control {
+   display: inline-block;
+   white-space: nowrap;
+   width:auto;
+   padding-right: 3%;
+}
+
+.v-radio-group .v-selection-control .v-label {
+   vertical-align: text-bottom;
+}
+
+</style>

--- a/src/utils/makeScanned/defaultConfig.ts
+++ b/src/utils/makeScanned/defaultConfig.ts
@@ -8,4 +8,5 @@ export const defaultConfig: ProcessConfig = {
   attenuate: 0.25,
   noise: "Gaussian",
   border: false,
+  punchHoles: "None",
 };

--- a/src/utils/makeScanned/defaultConfig.ts
+++ b/src/utils/makeScanned/defaultConfig.ts
@@ -7,6 +7,6 @@ export const defaultConfig: ProcessConfig = {
   blur: 0.5,
   attenuate: 0.25,
   noise: "Gaussian",
-  border: false,
+  background: false,
   punchHoles: "None",
 };

--- a/src/utils/makeScanned/defaultConfig.ts
+++ b/src/utils/makeScanned/defaultConfig.ts
@@ -7,6 +7,6 @@ export const defaultConfig: ProcessConfig = {
   blur: 0.5,
   attenuate: 0.25,
   noise: "Gaussian",
-  background: false,
+  background: "White",
   punchHoles: "None",
 };

--- a/src/utils/makeScanned/processConfig.ts
+++ b/src/utils/makeScanned/processConfig.ts
@@ -7,6 +7,7 @@ export interface ProcessConfig {
   attenuate: number;
   noise: string;
   border: boolean;
+  punchHoles: string;
 }
 
 export function getProcessCommand(
@@ -14,7 +15,7 @@ export function getProcessCommand(
   inputFilename: string,
   outputFilename: string
 ): string {
-  const { rotate, rotate_var, colorspace, blur, attenuate, noise, border } =
+  const { rotate, rotate_var, colorspace, blur, attenuate, noise, border, punchHoles } =
     config;
   const thresholdFunc = (value: number) => !(value > -0.05 && value < 0.05);
   const args: string[] = [];
@@ -24,6 +25,32 @@ export function getProcessCommand(
   if (border) {
     args.push("-bordercolor black -border 1");
   }
+
+
+if (punchHoles == "A4") {
+    // configure holes
+    args.push("-stroke black -fill white -strokewidth 1");
+
+    // top hole
+    args.push("-draw 'translate 67,615 circle 0,0 18,0'");
+
+    // bottom hole
+    args.push("-draw 'translate 67,1069 circle 0,0 18,0'");
+
+} else if (punchHoles == "Letter") {
+    // configure holes
+    args.push("-stroke black -fill white -strokewidth 1");
+
+    // top hole
+    args.push("-draw 'translate 72,188 circle 0,0 22,0'");
+
+    // middle hole
+    args.push("-draw 'translate 72,795 circle 0,0 22,0'");
+
+    // bottom hole
+    args.push("-draw 'translate 72,1400 circle 0,0 22,0'");
+}
+
 
   const randomRotate = (Math.random() * 2 - 1) * rotate_var + rotate;
 

--- a/src/utils/makeScanned/processConfig.ts
+++ b/src/utils/makeScanned/processConfig.ts
@@ -6,7 +6,7 @@ export interface ProcessConfig {
   blur: number;
   attenuate: number;
   noise: string;
-  background: boolean;
+  background: string;
   punchHoles: string;
 }
 
@@ -22,14 +22,31 @@ export function getProcessCommand(
   args.push("convert");
   args.push(inputFilename);
 
-  if (background) {
+  // configure appearance of border and punch holes
+  if (background == "White") {
+
+    if (punchHoles != "None") {
+      args.push("-stroke white -fill white -strokewidth 1");
+    }
+
+  } else if (background == "Black Border") {
+
     args.push("-bordercolor black -border 1");
+
+    if (punchHoles != "None") {
+      args.push("-stroke black -fill white -strokewidth 1");
+    }
+
+  } else if (background == "Black") {
+
+    if (punchHoles != "None") {
+      args.push("-stroke black -fill black -strokewidth 1");
+    }
   }
 
 
-if (punchHoles == "A4") {
-    // configure holes
-    args.push("-stroke black -fill white -strokewidth 1");
+  // draw punch holes
+  if (punchHoles == "A4") {
 
     // top hole
     args.push("-draw 'translate 67,615 circle 0,0 18,0'");
@@ -37,9 +54,7 @@ if (punchHoles == "A4") {
     // bottom hole
     args.push("-draw 'translate 67,1069 circle 0,0 18,0'");
 
-} else if (punchHoles == "Letter") {
-    // configure holes
-    args.push("-stroke black -fill white -strokewidth 1");
+  } else if (punchHoles == "Letter") {
 
     // top hole
     args.push("-draw 'translate 72,188 circle 0,0 22,0'");
@@ -49,13 +64,20 @@ if (punchHoles == "A4") {
 
     // bottom hole
     args.push("-draw 'translate 72,1400 circle 0,0 22,0'");
-}
+  }
 
 
   const randomRotate = (Math.random() * 2 - 1) * rotate_var + rotate;
 
   if (thresholdFunc(randomRotate)) {
-    args.push("-background white -virtual-pixel background");
+
+    if (background == "Black") {
+      args.push("-background black");
+    } else {
+      args.push("-background white");
+    }
+
+    args.push("-virtual-pixel background");
     args.push(`-distort SRT ${randomRotate.toFixed(2)}`);
     args.push("+repage");
   }

--- a/src/utils/makeScanned/processConfig.ts
+++ b/src/utils/makeScanned/processConfig.ts
@@ -6,7 +6,7 @@ export interface ProcessConfig {
   blur: number;
   attenuate: number;
   noise: string;
-  border: boolean;
+  background: boolean;
   punchHoles: string;
 }
 
@@ -15,14 +15,14 @@ export function getProcessCommand(
   inputFilename: string,
   outputFilename: string
 ): string {
-  const { rotate, rotate_var, colorspace, blur, attenuate, noise, border, punchHoles } =
+  const { rotate, rotate_var, colorspace, blur, attenuate, noise, background, punchHoles } =
     config;
   const thresholdFunc = (value: number) => !(value > -0.05 && value < 0.05);
   const args: string[] = [];
   args.push("convert");
   args.push(inputFilename);
 
-  if (border) {
+  if (background) {
     args.push("-bordercolor black -border 1");
   }
 


### PR DESCRIPTION
This PR adds the following options:
- punch holes (DIN A4 and US Letter)
- black background (phone apps sometimes create a black background when scanning)

The "Border" setting has been renamed to "Background".

The new options:
![settings](https://user-images.githubusercontent.com/17005217/166681585-22a07c43-19b5-462f-b679-a42a1a04454c.png)

The output (A4 punch holes, Black Border):
![hole_white](https://user-images.githubusercontent.com/17005217/166681653-dff9197c-950a-408b-9c75-a451880201db.png)
The output (A4 punch holes, Black):
![hole_black](https://user-images.githubusercontent.com/17005217/166681667-a7ebd0f4-f14f-4967-bdee-e168134e037d.png)

Note: The coordinates of the punch holes have been hard coded, since there is no way to find out the height of the page in the npm version of ImageMagick (the `%[fx:]` [operator](https://imagemagick.org/script/fx.php) doesn't work). The hard coded coordinates worked fine with every PDF I tested, since the number of pixels is the same after each PDF is rasterized with the same DPI.